### PR TITLE
Fix LivingEntity cast causing a crash

### DIFF
--- a/src/main/java/binaris/fabric_potions/mixin/LivingEntityMixin.java
+++ b/src/main/java/binaris/fabric_potions/mixin/LivingEntityMixin.java
@@ -58,14 +58,8 @@ public abstract class LivingEntityMixin {
     @Inject(at = @At("TAIL"), method = "modifyAppliedDamage", cancellable = true)
     public void FP_changeDamage(DamageSource source, float amount, CallbackInfoReturnable<Float> cir) {
         Entity entity = source.getAttacker();
+        float newAmount = cir.getReturnValue();
         if (entity instanceof LivingEntity attacker) {
-            float newAmount = cir.getReturnValue();
-
-            // Vulnerability
-            // Changes the value of newAmount to add more damage
-            if(livingEntity.hasStatusEffect(FP_Effects.VULNERABILITY))
-                newAmount += (cir.getReturnValue() + (cir.getReturnValue() * (0.2 * livingEntity.getStatusEffect(FP_Effects.VULNERABILITY).getAmplifier() + 1)));
-
             // Magic focus
             // Changes the value of newAmount to add more damage
             // Not effecting when attacker damages himself
@@ -88,17 +82,21 @@ public abstract class LivingEntityMixin {
             // Return damage to the attacker
             if(livingEntity.hasStatusEffect(FP_Effects.COUNTER))
                 attacker.damage(attacker.getDamageSources().indirectMagic(attacker, livingEntity), (float) (newAmount * 0.2) + livingEntity.getStatusEffect(FP_Effects.COUNTER).getAmplifier() + 1);
-
-            //Magic Shielding
-            // Reduces damage done
-            if (livingEntity.hasStatusEffect(FP_Effects.MAGIC_SHIELDING) && source.isOf(DamageTypes.INDIRECT_MAGIC) || livingEntity.hasStatusEffect(FP_Effects.MAGIC_SHIELDING) && source.isOf(DamageTypes.MAGIC))
-                newAmount -= ((livingEntity.getStatusEffect(FP_Effects.MAGIC_SHIELDING).getAmplifier() + 1) * Config.getFloat("magic_shielding.damage"));
-
-            // Inmortality
-            // Makes the entity invulnerable
-            if(livingEntity.hasStatusEffect(FP_Effects.INMORTALITY))
-                newAmount = 0;
-            cir.setReturnValue(newAmount);
         }
+        // Vulnerability
+        // Changes the value of newAmount to add more damage
+        if(livingEntity.hasStatusEffect(FP_Effects.VULNERABILITY))
+            newAmount += (cir.getReturnValue() + (cir.getReturnValue() * (0.2 * livingEntity.getStatusEffect(FP_Effects.VULNERABILITY).getAmplifier() + 1)));
+        
+        //Magic Shielding
+        // Reduces damage done
+        if (livingEntity.hasStatusEffect(FP_Effects.MAGIC_SHIELDING) && source.isOf(DamageTypes.INDIRECT_MAGIC) || livingEntity.hasStatusEffect(FP_Effects.MAGIC_SHIELDING) && source.isOf(DamageTypes.MAGIC))
+            newAmount -= ((livingEntity.getStatusEffect(FP_Effects.MAGIC_SHIELDING).getAmplifier() + 1) * Config.getFloat("magic_shielding.damage"));
+
+        // Inmortality
+        // Makes the entity invulnerable
+        if(livingEntity.hasStatusEffect(FP_Effects.INMORTALITY))
+            newAmount = 0;
+        cir.setReturnValue(newAmount);
     }
 }

--- a/src/main/java/binaris/fabric_potions/mixin/LivingEntityMixin.java
+++ b/src/main/java/binaris/fabric_potions/mixin/LivingEntityMixin.java
@@ -2,6 +2,7 @@ package binaris.fabric_potions.mixin;
 
 import binaris.fabric_potions.config.Config;
 import binaris.fabric_potions.registry.FP_Effects;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.damage.DamageTypes;
@@ -28,16 +29,15 @@ public abstract class LivingEntityMixin {
         // Gravitation
         // Change the value of q to change the gravity
         // q = 0.05 is the default value
-        if(this.hasStatusEffect(FP_Effects.GRAVITATION)){
-            if(livingEntity instanceof PlayerEntity player && player.isSneaking()){
-                switch(livingEntity.getStatusEffect(FP_Effects.GRAVITATION).getAmplifier()){
+        if (this.hasStatusEffect(FP_Effects.GRAVITATION)) {
+            if(livingEntity instanceof PlayerEntity player && player.isSneaking()) {
+                switch(livingEntity.getStatusEffect(FP_Effects.GRAVITATION).getAmplifier()) {
                     case 0 -> q -= 0.06;
                     case 1 -> q -= 0.055;
                     default -> q -= 0.05;
                 }
-            }
-            else{
-                switch(livingEntity.getStatusEffect(FP_Effects.GRAVITATION).getAmplifier()){
+            } else {
+                switch(livingEntity.getStatusEffect(FP_Effects.GRAVITATION).getAmplifier()) {
                     case 0 -> q -= 0.085;
                     case 1 -> q -= 0.089;
                     default -> q -= 0.091;
@@ -47,7 +47,7 @@ public abstract class LivingEntityMixin {
         return q;
     }
     @Inject(at = @At("HEAD"), method = "tickMovement")
-    public void FB_fallDamage(CallbackInfo ci){
+    public void FB_fallDamage(CallbackInfo ci) {
         // Gravitation
         // just to make sure that the entity takes fall damage when it has the effect
         if(livingEntity.hasStatusEffect(FP_Effects.GRAVITATION)){
@@ -56,57 +56,49 @@ public abstract class LivingEntityMixin {
     }
 
     @Inject(at = @At("TAIL"), method = "modifyAppliedDamage", cancellable = true)
-    public void FP_changeDamage(DamageSource source, float amount, CallbackInfoReturnable<Float> cir){
-        float newAmount = cir.getReturnValue();
-        LivingEntity attacker = (LivingEntity) source.getAttacker();
+    public void FP_changeDamage(DamageSource source, float amount, CallbackInfoReturnable<Float> cir) {
+        Entity entity = source.getAttacker();
+        if (entity instanceof LivingEntity attacker) {
+            float newAmount = cir.getReturnValue();
 
-        // Vulnerability
-        // Changes the value of newAmount to add more damage
-        if(livingEntity.hasStatusEffect(FP_Effects.VULNERABILITY)){
-            newAmount += (cir.getReturnValue() + (cir.getReturnValue() * (0.2 * livingEntity.getStatusEffect(FP_Effects.VULNERABILITY).getAmplifier() + 1)));
-        }
+            // Vulnerability
+            // Changes the value of newAmount to add more damage
+            if(livingEntity.hasStatusEffect(FP_Effects.VULNERABILITY))
+                newAmount += (cir.getReturnValue() + (cir.getReturnValue() * (0.2 * livingEntity.getStatusEffect(FP_Effects.VULNERABILITY).getAmplifier() + 1)));
 
-        // Magic focus
-        // Changes the value of newAmount to add more damage
-        // Not effecting when attacker damages himself
-        // to the target
-        // only if the damage is indirect magic or magic
-        if(attacker != null && attacker != livingEntity) {
-            if (attacker.hasStatusEffect(FP_Effects.MAGIC_FOCUS) && source.isOf(DamageTypes.INDIRECT_MAGIC) || attacker.hasStatusEffect(FP_Effects.MAGIC_FOCUS) && source.isOf(DamageTypes.MAGIC)) {
-                newAmount += ((attacker.getStatusEffect(FP_Effects.MAGIC_FOCUS).getAmplifier() + 1) * Config.getFloat("magic_focus.damage"));
-            }
-        }
+            // Magic focus
+            // Changes the value of newAmount to add more damage
+            // Not effecting when attacker damages himself
+            // to the target
+            // only if the damage is indirect magic or magic
+            if(attacker != livingEntity)
+                if (attacker.hasStatusEffect(FP_Effects.MAGIC_FOCUS) && source.isOf(DamageTypes.INDIRECT_MAGIC) || attacker.hasStatusEffect(FP_Effects.MAGIC_FOCUS) && source.isOf(DamageTypes.MAGIC))
+                    newAmount += ((attacker.getStatusEffect(FP_Effects.MAGIC_FOCUS).getAmplifier() + 1) * Config.getFloat("magic_focus.damage"));
 
-        // Magic inhibition
-        // Changes the value of newAmount to reduce damage done
-        // Not effecting when attacker damages himself
-        // to the target
-        // only if the damage is indirect magic or magic
-        if(attacker != null && attacker != livingEntity) {
-            if (attacker.hasStatusEffect(FP_Effects.MAGIC_INHIBITION) && source.isOf(DamageTypes.INDIRECT_MAGIC) || attacker.hasStatusEffect(FP_Effects.MAGIC_INHIBITION) && source.isOf(DamageTypes.MAGIC)) {
-                newAmount -= ((attacker.getStatusEffect(FP_Effects.MAGIC_INHIBITION).getAmplifier() + 1) * Config.getFloat("magic_inhibition.damage"));
-            }
-        }
+            // Magic inhibition
+            // Changes the value of newAmount to reduce damage done
+            // Not effecting when attacker damages himself
+            // to the target
+            // only if the damage is indirect magic or magic
+            if(attacker != livingEntity)
+                if (attacker.hasStatusEffect(FP_Effects.MAGIC_INHIBITION) && source.isOf(DamageTypes.INDIRECT_MAGIC) || attacker.hasStatusEffect(FP_Effects.MAGIC_INHIBITION) && source.isOf(DamageTypes.MAGIC))
+                    newAmount -= ((attacker.getStatusEffect(FP_Effects.MAGIC_INHIBITION).getAmplifier() + 1) * Config.getFloat("magic_inhibition.damage"));
 
-        // Counter
-        // Return damage to the attacker
-        if(livingEntity.hasStatusEffect(FP_Effects.COUNTER)){
-            if(attacker != null) {
+            // Counter
+            // Return damage to the attacker
+            if(livingEntity.hasStatusEffect(FP_Effects.COUNTER))
                 attacker.damage(attacker.getDamageSources().indirectMagic(attacker, livingEntity), (float) (newAmount * 0.2) + livingEntity.getStatusEffect(FP_Effects.COUNTER).getAmplifier() + 1);
-            }
-        }
 
-        //Magic Shielding
-        // Reduces damage done
-        if (livingEntity.hasStatusEffect(FP_Effects.MAGIC_SHIELDING) && source.isOf(DamageTypes.INDIRECT_MAGIC) || livingEntity.hasStatusEffect(FP_Effects.MAGIC_SHIELDING) && source.isOf(DamageTypes.MAGIC)) {
-            newAmount -= ((livingEntity.getStatusEffect(FP_Effects.MAGIC_SHIELDING).getAmplifier() + 1) * Config.getFloat("magic_shielding.damage"));
-        }
+            //Magic Shielding
+            // Reduces damage done
+            if (livingEntity.hasStatusEffect(FP_Effects.MAGIC_SHIELDING) && source.isOf(DamageTypes.INDIRECT_MAGIC) || livingEntity.hasStatusEffect(FP_Effects.MAGIC_SHIELDING) && source.isOf(DamageTypes.MAGIC))
+                newAmount -= ((livingEntity.getStatusEffect(FP_Effects.MAGIC_SHIELDING).getAmplifier() + 1) * Config.getFloat("magic_shielding.damage"));
 
-        // Inmortality
-        // Makes the entity invulnerable
-        if(livingEntity.hasStatusEffect(FP_Effects.INMORTALITY)){
-            newAmount = 0;
+            // Inmortality
+            // Makes the entity invulnerable
+            if(livingEntity.hasStatusEffect(FP_Effects.INMORTALITY))
+                newAmount = 0;
+            cir.setReturnValue(newAmount);
         }
-        cir.setReturnValue(newAmount);
     }
 }


### PR DESCRIPTION
DamageSource.getAttacker() isn't always a LivingEntity. This causes a crash when, for example an arrow hits you. This PR fixes this issue by using an instanceof check to ensure that source.getAttacker() both isn't null and is an instanceof LivingEntity.